### PR TITLE
ArgoCD - spot instances

### DIFF
--- a/src/infrastructure/gcloud/_.variables.tf
+++ b/src/infrastructure/gcloud/_.variables.tf
@@ -70,3 +70,8 @@ variable "argocd_version" {
   type        = string
   default     = "8.0.17"
 }
+
+variable "argocd_use_spot_instances" {
+  description = "True/false to use Google Clouds spot instances."
+  type        = bool
+}

--- a/src/infrastructure/gcloud/argocd.tf
+++ b/src/infrastructure/gcloud/argocd.tf
@@ -11,6 +11,20 @@ resource "helm_release" "argocd" {
     yamlencode({
       global = {
         domain = var.argocd_domain
+        nodeSelector = var.argocd_use_spot_instances ? {
+          "cloud.google.com/gke-spot" = "true"
+        } : {}
+
+        affinity = var.argocd_use_spot_instances ? {
+          nodeAffinity = {
+            matchExpressions = {
+              "cloud.google.com/gke-spot" = {
+                operator = "in"
+                values = [ "true" ]
+              }
+            }
+          }
+        } : {}
       }
 
       configs = {

--- a/src/infrastructure/gcloud/default.tfvars
+++ b/src/infrastructure/gcloud/default.tfvars
@@ -20,4 +20,6 @@ release_channel = "REGULAR"  # Other options: RAPID, STABLE
 # node_service_account = "your-service-account@your-project.iam.gserviceaccount.com"
 
 dns_zone_name = "gke-autopilot"
+
 argocd_domain = "argocd.gke-auto.squirreldev.de"
+argocd_use_spot_instances = true


### PR DESCRIPTION
Enables optional use of Google Cloud spot instances for ArgoCD by adding a configurable variable.